### PR TITLE
Fix react warnings

### DIFF
--- a/renderers/components/figure.tsx
+++ b/renderers/components/figure.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 export const renderFigure = (src: string, alt: string, caption?: string, credit?: string) => {
     return <figure className="app-c-figure" lang="en">
                 <image className="app-c-figure__image" src={src} alt={alt}/>
-                <figcaption class="app-c-figure__figcaption">
+                <figcaption className="app-c-figure__figcaption">
                     {captionElem(caption)}
                     {creditElem(credit)}
                 </figcaption>
@@ -13,7 +13,7 @@ export const renderFigure = (src: string, alt: string, caption?: string, credit?
 
 const captionElem = (caption?: string) => {
     if (caption) {
-        return <p class="app-c-figure__figcaption-text">{caption}</p>
+        return <p className="app-c-figure__figcaption-text">{caption}</p>
     } else {
         //work out how to not return elem here
         return <p/>
@@ -22,7 +22,7 @@ const captionElem = (caption?: string) => {
 
 const creditElem = (credit?: string) => {
     if (credit) {
-        return <p class="app-c-figure__figcaption-credi">{credit}</p>
+        return <p className="app-c-figure__figcaption-credi">{credit}</p>
     } else {
         //work out how to not return elem here
         return <p/>

--- a/renderers/components/footer.tsx
+++ b/renderers/components/footer.tsx
@@ -28,18 +28,18 @@ export const footer = () => {
 }
 
 const navigationLinksDiv = (links: NavigationLink[]) => {
-    return links.map( l => 
+    return React.Children.toArray(links.map( l => 
         <div className={ `${columnWidthClass(columnNo(l.label))}  govuk-!-display-none-print` }>
             <h2 className="govuk-footer__heading govuk-heading-m">{l.label}</h2>
             <ul className={ listClasses(columnNo(l.label)) }>
-                { l.menu_contents.map( (i: Item ) => 
+                { React.Children.toArray(l.menu_contents.map( (i: Item ) => 
                     <li className="govuk-footer__list-item">
                         <a href={ i.href } className="govuk-footer__link">{ i.label }</a>
                     </li>
-                ) }
+                )) }
             </ul>
         </div>
-        )
+    ))
 }
 
 const columnNo = (title: String): number => (title === "Topics")? 2 : 1

--- a/renderers/components/title.tsx
+++ b/renderers/components/title.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 export const title = (t: String, documentType: String) => {
     return <div className="gem-c-title govuk-!-margin-top-8 govuk-!-margin-bottom-8">
-              <span class="govuk-caption-xl gem-c-title__context">{documentType}</span>
+              <span className="govuk-caption-xl gem-c-title__context">{documentType}</span>
                <h1 className="govuk-heading-xl gem-c-title__text">{t}</h1>
            </div>
 }

--- a/renderers/renderPage.tsx
+++ b/renderers/renderPage.tsx
@@ -17,9 +17,9 @@ export const renderPage = (page) => {
               { header() }
               <div className="wrapper govuk-width-container">
                 <div className="gem-c-breadcrumbs govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile" data-module="gem-track-click">
-                  <ol class="govuk-breadcrumbs__list">
-                        <li class="govuk-breadcrumbs__list-item">
-                          <a data-track-category="homeLinkClicked" data-track-action="homeBreadcrumb" data-track-label="" data-track-options="{}" class="govuk-breadcrumbs__link" href="/">Home</a>
+                  <ol className="govuk-breadcrumbs__list">
+                        <li className="govuk-breadcrumbs__list-item">
+                          <a data-track-category="homeLinkClicked" data-track-action="homeBreadcrumb" data-track-label="" data-track-options="{}" className="govuk-breadcrumbs__link" href="/">Home</a>
                         </li>
                   </ol>
                 </div>

--- a/renderers/speech.tsx
+++ b/renderers/speech.tsx
@@ -11,10 +11,10 @@ export const renderSpeech = (contentItem: SpeechSchema) => {
       {title(contentItem.title, toTitleCase(contentItem.document_type))}
       <div className = "gem-c-lead-paragraph"><p>{contentItem.title}</p></div>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="content-bottom-margin"></div>
-            <div class="responsive-bottom-margin">
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <div className="content-bottom-margin"></div>
+            <div className="responsive-bottom-margin">
                 { image(contentItem)}
                 {renderGovspeakElem(contentItem.details.body)}
             </div>


### PR DESCRIPTION
Two flavours of warning:

1) The classic of having to use "className" instead of "class" because it's the DOM property not the HTML attribute name

2) React is fussy about lists of
children if the children don't have keys. This isn't a problem for us because we're rendering everything statically, so it doesn't matter if react can't track which element is which, but it still complains. Adding React.Children.toArray fixes this.